### PR TITLE
For updating New Failure in Test Run Method Results Object

### DIFF
--- a/force-app/main/default/classes/TestRunProcessor.cls
+++ b/force-app/main/default/classes/TestRunProcessor.cls
@@ -137,6 +137,7 @@ public with sharing class TestRunProcessor implements Schedulable {
                     break;
                 }
             }
+            failure.New_Failure__c=newFailure;
             if (newFailure)
                 newTestFailures++;
         }


### PR DESCRIPTION
Currently, related List Test Run Method Results not showing failed test 'New Failure' field is not marked.